### PR TITLE
Update docs/user-guide/openai-api/langchain.md: set the model name to `NA` in the API server

### DIFF
--- a/docs/user-guide/openai-api/langchain.md
+++ b/docs/user-guide/openai-api/langchain.md
@@ -85,7 +85,7 @@ Finally, use the following command lines to start an API server for the model.  
 
 
 ```
-wasmedge --dir .:. --nn-preload default:GGML:AUTO:Llama-2-7b-chat-hf-Q5_K_M.gguf llama-api-server.wasm -p llama-2-chat -c 4096
+wasmedge --dir .:. --nn-preload default:GGML:AUTO:Llama-2-7b-chat-hf-Q5_K_M.gguf llama-api-server.wasm -p llama-2-chat -c 4096 -m NA
 ```
 
 


### PR DESCRIPTION
The command to start the API server should set the model name of the chat model to `NA` (with the option `-m, --model-name <MODEL_NAME>`) because the chatbot web app assumes that the model is `NA` (the default in `LlamaEdgeChatService`).

https://github.com/langchain-ai/langchain/blob/0e916d0d552fde282fa3bf51010c47536913bba3/libs/community/langchain_community/chat_models/llama_edge.py#L72-L83

A better solution might be to have the chatbot web app use the `/v1/models` endpoint to get the list of available models and display a dropdown to select the model to use, but I don't know how to do this with LangChain.